### PR TITLE
Fix link to rules-of-use

### DIFF
--- a/app/views/catalog/_password_modal.html.erb
+++ b/app/views/catalog/_password_modal.html.erb
@@ -15,7 +15,7 @@
                 Your password is:
                 <script>document.write('<span id="hint">'+Math.random().toString(36).slice(2)+'</span>');</script>
               </p>
-            <iframe src="/plain/rules-of-use" style="width: 100%;"></iframe>
+            <iframe src="/rules-of-use" style="width: 100%;"></iframe>
           </div>
           <div class="modal-footer">
             I have read and agree to the terms and conditions:


### PR DESCRIPTION
# Rules of use
Fixes iframe popup to show rules of use, instead of `500` error page